### PR TITLE
Remove hadoop-demo submodule commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .rake_test_cache
-
+.chef

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .rake_test_cache
+.chef
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .rake_test_cache
-.chef
 


### PR DESCRIPTION
This pull request removes the unrelated submodule hash update from a recent commit.