### PR TITLE
Fix the link to the knife documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you use the `ssl_cert` task, change the values in the `config/rake.rb` file a
 
 The second config file, `.chef/knife.rb` is a repository specific configuration file for knife. If you're using the Opscode Platform, you can download one for your organization from the management console. If you're using the Open Source Chef Server, you can generate a new one with `knife configure`. For more information about configuring Knife, see the Knife documentation.
 
-http://help.opscode.com/faqs/chefbasics/knife
+http://docs.opscode.com/knife.html
 
 Next Steps
 ==========


### PR DESCRIPTION
The link in the top-level README to the documentation of `knife` is broken. This updates it to the current version.