### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you use the `ssl_cert` task, change the values in the `config/rake.rb` file a
 
 The second config file, `.chef/knife.rb` is a repository specific configuration file for knife. If you're using the Opscode Platform, you can download one for your organization from the management console. If you're using the Open Source Chef Server, you can generate a new one with `knife configure`. For more information about configuring Knife, see the Knife documentation.
 
-http://help.opscode.com/faqs/chefbasics/knife
+http://wiki.opscode.com/display/chef/Knife
 
 Next Steps
 ==========


### PR DESCRIPTION
Replaced the "http://help.opscode.com/faqs/chefbasics/knife" link, which redirected to general support, in stead of the Knife documentation.